### PR TITLE
config: avoided an error with NGINX 1.17.0 and above.

### DIFF
--- a/config
+++ b/config
@@ -19,18 +19,21 @@ HTTP_SRCACHE_FILTER_DEPS="                                                  \
                         $ngx_addon_dir/src/ngx_http_srcache_headers.h       \
                         "
 
-# nginx won't have HTTP_POSTPONE_FILTER_MODULE & HTTP_POSTPONE_FILTER_SRCS
-# defined since 1.9.11
-if test -z "$HTTP_POSTPONE_FILTER_MODULE"; then
-    HTTP_POSTPONE_FILTER_MODULE=ngx_http_postpone_filter_module
-    HTTP_POSTPONE_FILTER_SRCS=src/http/ngx_http_postpone_filter_module.c
-fi
+# nginx 1.17.0+ unconditionally enables the postpone filter
+if [ ! -z "$HTTP_POSTPONE" ]; then
+    # nginx won't have HTTP_POSTPONE_FILTER_MODULE & HTTP_POSTPONE_FILTER_SRCS
+    # defined since 1.9.11
+    if [ -z "$HTTP_POSTPONE_FILTER_MODULE" ]; then
+        HTTP_POSTPONE_FILTER_MODULE=ngx_http_postpone_filter_module
+        HTTP_POSTPONE_FILTER_SRCS=src/http/ngx_http_postpone_filter_module.c
+    fi
 
-# This module depends upon the postpone filter being activated
-if [ $HTTP_POSTPONE != YES ]; then
-    HTTP_FILTER_MODULES="$HTTP_FILTER_MODULES $HTTP_POSTPONE_FILTER_MODULE"
-    HTTP_SRCS="$HTTP_SRCS $HTTP_POSTPONE_FILTER_SRCS"
-    HTTP_POSTPONE=YES
+    # This module depends upon the postpone filter being activated
+    if [ $HTTP_POSTPONE != YES ]; then
+        HTTP_FILTER_MODULES="$HTTP_FILTER_MODULES $HTTP_POSTPONE_FILTER_MODULE"
+        HTTP_SRCS="$HTTP_SRCS $HTTP_POSTPONE_FILTER_SRCS"
+        HTTP_POSTPONE=YES
+    fi
 fi
 
 if [ -n "$ngx_module_link" ]; then


### PR DESCRIPTION
Currently, building those modules with NGINX 1.17.0+ produces the following errors:
```
/path/to/echo-nginx-module/config: line 41: [: !=: unary operator expected
/path/to/srcache-nginx-module/config: line 30: [: !=: unary operator expected
```

Since the `HTTP_POSTPONE` variable is not defined. However, since the postpone filter is unconditionally enabled with NGINX 1.17.0 and above, we can simply skip this logic.

See: https://github.com/nginx/nginx/commit/a39380a41e7d7ceeda2c0526c5df474f158c6a53

Sister PR: https://github.com/openresty/echo-nginx-module/pull/89