### PR TITLE
Update handling of cache_control changed in nginx 1.23.0 (Fixes #96)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ env:
   matrix:
     - NGINX_VERSION=1.17.8
     - NGINX_VERSION=1.19.9
+    - NGINX_VERSION=1.23.0
 
 services:
  - memcache

--- a/src/ngx_http_srcache_headers.c
+++ b/src/ngx_http_srcache_headers.c
@@ -256,9 +256,17 @@ static ngx_int_t
 ngx_http_srcache_process_multi_header_lines(ngx_http_request_t *r,
     ngx_table_elt_t *h, ngx_uint_t offset)
 {
+#if defined(nginx_version) && nginx_version < 1023000
     ngx_array_t      *pa;
+#endif
     ngx_table_elt_t  *ho, **ph;
 
+#if defined(nginx_version) && nginx_version >= 1023000
+    ph = (ngx_table_elt_t **) ((char *) &r->headers_out + offset);
+    while (*ph) {
+      ph = &(*ph)->next;
+    }
+#else
     pa = (ngx_array_t *) ((char *) &r->headers_out + offset);
 
     if (pa->elts == NULL) {
@@ -272,6 +280,7 @@ ngx_http_srcache_process_multi_header_lines(ngx_http_request_t *r,
     if (ph == NULL) {
         return NGX_ERROR;
     }
+#endif
 
     ho = ngx_list_push(&r->headers_out.headers);
     if (ho == NULL) {
@@ -280,6 +289,9 @@ ngx_http_srcache_process_multi_header_lines(ngx_http_request_t *r,
 
     *ho = *h;
     *ph = ho;
+#if defined(nginx_version) && nginx_version >= 1023000
+    ho->next = NULL;
+#endif
 
     return NGX_OK;
 }

--- a/src/ngx_http_srcache_util.c
+++ b/src/ngx_http_srcache_util.c
@@ -546,15 +546,34 @@ ngx_int_t
 ngx_http_srcache_response_no_cache(ngx_http_request_t *r,
     ngx_http_srcache_loc_conf_t *conf, ngx_http_srcache_ctx_t *ctx)
 {
-    ngx_table_elt_t   **ccp;
     ngx_table_elt_t    *h;
+#if defined(nginx_version) && nginx_version >= 1023000
+    ngx_table_elt_t    *cc;
+#else
+    ngx_table_elt_t   **ccp;
     ngx_uint_t          i;
+#endif
     u_char             *p, *last;
     ngx_int_t           n;
     time_t              expires;
 
     dd("checking response cache control settings");
 
+#if defined(nginx_version) && nginx_version >= 1023000
+    cc = r->headers_out.cache_control;
+
+    if (cc == NULL) {
+        goto check_expires;
+    }
+
+    for (cc = cc->next; cc; cc = cc->next) {
+        if (!cc->hash) {
+            continue;
+        }
+
+        p = cc->value.data;
+        last = p + cc->value.len;
+#else
     ccp = r->headers_out.cache_control.elts;
 
     if (ccp == NULL) {
@@ -568,6 +587,7 @@ ngx_http_srcache_response_no_cache(ngx_http_request_t *r,
 
         p = ccp[i]->value.data;
         last = p + ccp[i]->value.len;
+#endif
 
         if (!conf->store_private
             && ngx_strlcasestrn(p, last, (u_char *) "private", 7 - 1) != NULL)

--- a/src/ngx_http_srcache_util.c
+++ b/src/ngx_http_srcache_util.c
@@ -566,7 +566,7 @@ ngx_http_srcache_response_no_cache(ngx_http_request_t *r,
         goto check_expires;
     }
 
-    for (cc = cc->next; cc; cc = cc->next) {
+    for (; cc; cc = cc->next) {
         if (!cc->hash) {
             continue;
         }


### PR DESCRIPTION
This pull request fixes [Nginx 1.23.0 header changes · Issue #96 · openresty/srcache-nginx-module](https://github.com/openresty/srcache-nginx-module/issues/96).
See https://github.com/nginx/nginx/commit/3aef1d693f3cc431563a7e6a6aba6a34e52 for changes in nginx.
